### PR TITLE
Add brand guideline stories and Figma integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: "\U0001F41E Bug report"
+about: "If something isn't working as expected."
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+## Bug Report
+
+**Current behavior**
+A clear and concise description of the behaviour.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F4A1 Feature request"
+about: "Suggest a new idea"
+title: ''
+labels: 'Type: Enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: "\U0001F4AC Question"
+about: "Clear something up"
+title: ''
+labels: 'Type: Question'
+assignees: ''
+
+---
+
+**What's your question?**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Related issue
+Closes #
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Screenshots (before and after the change):
+<!--- if appropriate -->

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,5 @@
 module.exports = {
   stories: [
-    '../src/Introduction.stories.mdx',
     '../src/**/*.stories.mdx',
     '../src/**/*.stories.@(js|jsx|ts|tsx)',
   ],

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,7 @@ module.exports = {
     '@storybook/preset-scss',
     '@storybook/addon-a11y',
     '@storybook/addon-interactions',
+    'storybook-addon-mdx-embed',
     // '@storybook/preset-create-react-app'
     // 'storybook-addon-material-ui',
   ],

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -41,4 +41,9 @@ export const parameters = {
     // sets the execution mode for the addon
     manual: false,
   },
+  options: {
+    storySort: {
+      order: ['Introduction', 'Colors', 'Typography'],
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "types": "dist/index.d.ts",
   "overrides": {
     "mdx-embed": {
-      "react": "^16.9.0"
+      "react": "^17.0.1"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
+  "overrides": {
+    "mdx-embed": {
+      "react": "^16.9.0"
+    }
+  },
   "dependencies": {
     "@material-ui/core": "^4.12.4"
   },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.3.1",
+    "mdx-embed": "^1.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.2",
     "react-is": "^18.0.0",
@@ -115,6 +116,7 @@
     "rollup-plugin-postcss": "^4.0.1",
     "sass": "^1.43.5",
     "sass-loader": "^12.3.0",
+    "storybook-addon-mdx-embed": "^1.0.0",
     "style-loader": "^3.3.1",
     "styled-components": "^5.3.5",
     "typescript": "^4.4.4"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   "types": "dist/index.d.ts",
   "overrides": {
     "mdx-embed": {
-      "react": "^17.0.1"
+      "react": "^17.0.0",
+      "react-dom": "^17.0.0"
     }
   },
   "dependencies": {

--- a/src/config/styles.ts
+++ b/src/config/styles.ts
@@ -1,0 +1,113 @@
+import { css } from '@storybook/theming';
+import { rgba } from 'polished';
+
+// Global style variables
+export const background = {
+  app: '#e8ebec',
+  light: '#f3f5f5',
+  positive: '#E1FFD4',
+  negative: '#FEDED2',
+  warning: '#FFF5CF',
+  calmBlue: '#E3F3FF',
+};
+
+export const color = {
+  // Palette
+  primary: '#f8c608',
+  primaryLight: '#ffe275',
+
+  // Monochrome
+  lightest: '#FFFFFF',
+  lighter: '#F8F8F8',
+  light: '#F3F3F3',
+  mediumlight: '#EEEEEE',
+  medium: '#DDDDDD',
+  mediumdark: '#999999',
+  dark: '#666666',
+  darker: '#444444',
+  darkest: '#333333',
+
+  border: 'rgba(0,0,0,0.1)',
+
+  // Status
+  supported: '#0ccb58',
+  disputed: '#f72525',
+  conflicting: '#fecd0c',
+  unknown: '#cdd4d7',
+};
+
+export const spacing = {
+  padding: {
+    small: 10,
+    medium: 20,
+    large: 30,
+  },
+  borderRadius: {
+    small: 5,
+    default: 10,
+  },
+};
+
+export const typography = {
+  type: {
+    primary: '"Arizona Serif", "Georgia", sans-serif',
+    secondary: '"DM Mono", monospace',
+  },
+  weight: {
+    regular: '400',
+    bold: '700',
+  },
+  size: {
+    s1: 16,
+    s2: 21,
+    s3: 28,
+    m1: 38,
+    m2: 50,
+    m3: 68,
+    l1: 90,
+    l2: 120,
+    l3: 160,
+    code: 38,
+  },
+} as const;
+
+export const breakpoint = 600;
+export const pageMargin = 5.55555;
+
+export const pageMargins = css`
+  padding: 0 ${spacing.padding.medium}px;
+  @media (min-width: ${breakpoint * 1}px) {
+    margin: 0 ${pageMargin * 1}%;
+  }
+  @media (min-width: ${breakpoint * 2}px) {
+    margin: 0 ${pageMargin * 2}%;
+  }
+  @media (min-width: ${breakpoint * 3}px) {
+    margin: 0 ${pageMargin * 3}%;
+  }
+  @media (min-width: ${breakpoint * 4}px) {
+    margin: 0 ${pageMargin * 4}%;
+  }
+`;
+
+export const hoverEffect = css`
+  border: 1px solid ${color.border};
+  border-radius: ${spacing.borderRadius.small}px;
+  transition: background 150ms ease-out, border 150ms ease-out,
+    transform 150ms ease-out;
+  &:hover,
+  &.__hover {
+    border-color: ${rgba(color.primaryLight, 0.5)};
+    transform: translate3d(0, -3px, 0);
+    box-shadow: rgba(0, 0, 0, 0.08) 0 3px 10px 0;
+  }
+  &:active,
+  &.__active {
+    border-color: ${rgba(color.primaryLight, 1)};
+    transform: translate3d(0, 0, 0);
+  }
+`;
+
+export const zIndex = {
+  tooltip: 2147483647,
+};

--- a/src/stories/Colors.stories.mdx
+++ b/src/stories/Colors.stories.mdx
@@ -1,0 +1,54 @@
+import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
+
+import { color } from '../config/styles';
+
+<Meta title="Colors" />
+
+# Colors
+
+<ColorPalette>
+  <ColorItem
+    title="theme.color.primary"
+    subtitle="Primary"
+    colors={[color.primary]}
+  />
+  <ColorItem
+    title="theme.color.secondary"
+    subtitle="Primary light"
+    colors={[color.primaryLight]}
+  />
+  <ColorItem
+    title="theme.color.supported"
+    subtitle="Supported Claim"
+    colors={[color.supported]}
+  />
+  <ColorItem
+    title="theme.color.disputed"
+    subtitle="Disputed Claim"
+    colors={[color.disputed]}
+  />
+  <ColorItem
+    title="theme.color.conflicting"
+    subtitle="Conflicting sources"
+    colors={[color.conflicting]}
+  />
+  <ColorItem
+    title="theme.color.unknown"
+    subtitle="Unknown support"
+    colors={[color.unknown]}
+  />
+  <ColorItem
+    title="Monochrome"
+    colors={[
+      color.darkest,
+      color.darker,
+      color.dark,
+      color.mediumdark,
+      color.medium,
+      color.mediumlight,
+      color.light,
+      color.lighter,
+      color.lightest,
+    ]}
+  />
+</ColorPalette>

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -1,8 +1,17 @@
+import { Figma } from 'mdx-embed';
+
 <Meta title="Introduction" />
 
 # Get started
 
 Factiverse Design System is a reusable component library that helps Factiverse contributors build UIs faster. The goal is to make building durable UIs more productive and satisfying.
+
+## Brand guidelines
+
+<Figma
+  title="branding"
+  url="file/3h1UoEM7kSHLqOHK04Z8yG/Factiverse-brand-guidelines?node-id=0%3A1"
+/>
 
 ## Install
 

--- a/src/stories/Typography.stories.mdx
+++ b/src/stories/Typography.stories.mdx
@@ -1,0 +1,115 @@
+import { Meta, Typeset, Canvas } from '@storybook/addon-docs/blocks';
+
+import { typography } from '../config/styles';
+
+import { Typography } from '@mui/material';
+
+<Meta title="Typography" />
+
+# Typography
+
+## Hierarchy
+
+<Canvas columns={2} withSource="open">
+  <Typography variant="h4" fontFamily="DM Mono">
+    Mission
+  </Typography>
+  <Typography
+    variant="h1"
+    fontFamily="Arizona Serif"
+    sx={{ fontWeight: '200' }}
+  >
+    Unblurring the lines between fact and misinformation
+  </Typography>
+  <Typography variant="body" fontFamily="Arizona Serif">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+    do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam, quis nostrud.
+  </Typography>
+</Canvas>
+
+## Headline/Body text
+
+**Font:** ABC Arizona Serif Light
+
+**Weights:** 400(regular), 700(bold)
+
+### Font weight: regular
+
+<Typeset
+  fontSizes={[
+    Number(typography.size.s1),
+    Number(typography.size.s2),
+    Number(typography.size.s3),
+    Number(typography.size.m1),
+    Number(typography.size.m2),
+    Number(typography.size.m3),
+    Number(typography.size.l1),
+    Number(typography.size.l2),
+    Number(typography.size.l3),
+  ]}
+  fontFamily="Arizona Serif"
+  fontWeight={typography.weight.regular}
+/>
+
+### Font weight: bold
+
+<Typeset
+  fontSizes={[
+    Number(typography.size.s1),
+    Number(typography.size.s2),
+    Number(typography.size.s3),
+    Number(typography.size.m1),
+    Number(typography.size.m2),
+    Number(typography.size.m3),
+    Number(typography.size.l1),
+    Number(typography.size.l2),
+    Number(typography.size.l3),
+  ]}
+  fontFamily="Arizona Serif"
+  fontWeight={typography.weight.bold}
+/>
+
+## Overline heading/Buttons
+
+**Font:** DM Mono Light
+
+**Weights:** 400(regular), 700(bold)
+
+### Font weight: regular
+
+<Typeset
+  fontSizes={[
+    Number(typography.size.s1),
+    Number(typography.size.s2),
+    Number(typography.size.s3),
+    Number(typography.size.m1),
+    Number(typography.size.m2),
+    Number(typography.size.m3),
+    Number(typography.size.l1),
+    Number(typography.size.l2),
+    Number(typography.size.l3),
+  ]}
+  fontFamily="DM Mono"
+  fontWeight={typography.weight.regular}
+/>
+
+### Font weight: bold
+
+<Typeset
+  fontSizes={[
+    Number(typography.size.s1),
+    Number(typography.size.s2),
+    Number(typography.size.s3),
+    Number(typography.size.m1),
+    Number(typography.size.m2),
+    Number(typography.size.m3),
+    Number(typography.size.l1),
+    Number(typography.size.l2),
+    Number(typography.size.l3),
+  ]}
+  fontFamily="DM Mono"
+  fontWeight={typography.weight.bold}
+/>


### PR DESCRIPTION
Added stories for typography and colors.
Using mdx-embed to display Figma files inline (check out their [own storybook](https://www.mdx-embed.com/?path=/docs/introduction--page) for more).
Also added issue and pull request templates, which we have in all repos.
<img width="1403" alt="Screenshot 2022-04-27 at 02 39 34" src="https://user-images.githubusercontent.com/44401648/165415469-67bb256c-cdd0-4ca3-a215-38abb0427c2b.png">
<img width="1362" alt="Screenshot 2022-04-27 at 02 39 42" src="https://user-images.githubusercontent.com/44401648/165415482-ea5f068e-a63b-47e8-b0de-666d6e3f36c6.png">

