### PR TITLE
Add phosphor icons script to head

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<script src="https://unpkg.com/phosphor-icons"></script>


### PR DESCRIPTION
## Description
Added the Phosphor Icons script to the html head by using preview-head.html

## Usage
```
// class name is the name of the icon
<i className="ph-smiley"></i>

// style can be adjusted in the same way as a font
<i className="ph-heart-fill" style={{ color: 'hotpink' }}></i>

// styling shortcuts can be used by assigning other classes
<i className="ph-cube-thin ph-7x"></i>
```

## Screenshots
<img width="677" alt="Screenshot 2022-05-03 at 16 50 11" src="https://user-images.githubusercontent.com/44401648/166477373-a38e9ea5-4327-4307-a87e-14aa88d61c5e.png">
