### PR TITLE
Fix MUI warning and favicon

### DIFF
--- a/src/components/Favicon/Favicon.tsx
+++ b/src/components/Favicon/Favicon.tsx
@@ -47,7 +47,7 @@ const Favicon: React.FC<FaviconProps> = ({ rootDomain }) => {
   };
 
   return (
-    <Paper sx={{ height: 34, width: 34 }} variant="outlined" elevation={3}>
+    <Paper sx={{ height: 34, width: 34 }} variant="outlined">
       <img
         width={32}
         // DuckDuckGo scrapes favicons and catches all different ways of adding them to a website

--- a/src/components/Favicon/Favicon.tsx
+++ b/src/components/Favicon/Favicon.tsx
@@ -47,7 +47,7 @@ const Favicon: React.FC<FaviconProps> = ({ rootDomain }) => {
   };
 
   return (
-    <Paper sx={{ height: 34, width: 34 }} variant="outlined">
+    <Paper sx={{ height: 32, width: 32 }} variant="outlined">
       <img
         width={32}
         // DuckDuckGo scrapes favicons and catches all different ways of adding them to a website

--- a/src/components/Favicon/Favicon.tsx
+++ b/src/components/Favicon/Favicon.tsx
@@ -52,7 +52,7 @@ const Favicon: React.FC<FaviconProps> = ({ rootDomain }) => {
         width={32}
         // DuckDuckGo scrapes favicons and catches all different ways of adding them to a website
         src={
-          'https://icons.duckduckgo.com/ip2/www.' +
+          'https://icons.duckduckgo.com/ip3/www.' +
           getRootDomain(rootDomain) +
           '.ico'
         }


### PR DESCRIPTION
## Description
- Using both `variant="outlined"` and `elevation={3}` caused an MUI warning, so elevation was removed
- Fixed size of favicons (32x32 instead of 34x34)
- Use newer favicon api from Duckduckgo to find even more favicons